### PR TITLE
Handle WP_Error object on wp_remote_get failure.

### DIFF
--- a/dude-facebook-feed.php
+++ b/dude-facebook-feed.php
@@ -112,7 +112,7 @@ Class Dude_Facebook_Feed {
     $parameters = http_build_query( $parameters );
 		$response = wp_remote_get( 'https://graph.facebook.com/'.$fbid.'/feed/?'.$parameters );
 
-		if( $response['response']['code'] !== 200 ) {
+		if( is_wp_error( $response ) || $response['response']['code'] !== 200 ) {
 			self::_write_log( 'response status code not 200 OK, fbid: '.$fbid );
 			return false;
 		}


### PR DESCRIPTION
The wp_remote_get function sometimes returns an WP Error object, which isn't handled by the plugin: https://codex.wordpress.org/Function_Reference/wp_remote_get